### PR TITLE
Stop broadcast extension when app is closed

### DIFF
--- a/example/ios/BigbluebuttonMobileSdkExample/AppDelegate.swift
+++ b/example/ios/BigbluebuttonMobileSdkExample/AppDelegate.swift
@@ -6,6 +6,7 @@
 
 import UIKit
 import bigbluebutton_mobile_sdk
+import bigbluebutton_mobile_sdk_common
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, RCTBridgeDelegate {
@@ -35,7 +36,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, RCTBridgeDelegate {
 
     return true
   }
-
+  
+  func applicationWillTerminate(_ application: UIApplication) {
+    BigBlueButtonSDK.onAppTerminated()
+  }
+  
   func sourceURL(for bridge: RCTBridge!) -> URL! {
 //#if DEBUG
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index", fallbackResource:nil)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -362,7 +362,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   bigbluebutton-mobile-sdk: c22205a921c38e43d5c5ec2c8f47d890db5e189e
-  bigbluebutton-mobile-sdk-broadcast-upload-extension: 702331796aa06d3cac9fc202cb20888b3e3a57eb
+  bigbluebutton-mobile-sdk-broadcast-upload-extension: 755c8bb697a1a45855ad44b6b0ad95a62cc978d7
   bigbluebutton-mobile-sdk-common: 287c9acc965d00e72d71a0d2b020fa8e483e7a11
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cde416483dac037923206447da6e1454df403714
@@ -396,4 +396,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 1cef60f4fb4cef93dc6de3cb3b53463e5f48a9bc
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/ios-broadcast-upload-extension/Classes/BBBSampleHandler.swift
+++ b/ios-broadcast-upload-extension/Classes/BBBSampleHandler.swift
@@ -12,9 +12,10 @@ open class BBBSampleHandler : RPBroadcastSampleHandler {
     // Logger (these messages are displayed in the console application)
     private var logger = os.Logger(subsystem: "BigBlueButtonMobileSDK", category: "BBBSampleHandler")
     private var appGroupName:String = "";
-    private var createOfferCallObserver:NSKeyValueObservation?;
-    private var setRemoteSDPCallObserver:NSKeyValueObservation?;
+    private var createScreenShareOfferObserver:NSKeyValueObservation?;
+    private var setScreenShareRemoteSDPOBserver:NSKeyValueObservation?;
     private var addScreenShareRemoteIceCandidateObserver:NSKeyValueObservation?;
+    private var onApplicationTerminatedObserver:NSKeyValueObservation?;
     private var screenBroadcaster:ScreenBroadcasterService?;
     
     open func setAppGroupName(appGroupName:String) {
@@ -36,9 +37,16 @@ open class BBBSampleHandler : RPBroadcastSampleHandler {
         
         self.screenBroadcaster = ScreenBroadcasterService(appGroupName: appGroupName)
         
+        // Handle quit application to finish broadcast togheter
+        logger.info("Configuring observer for finishApplication")
+        self.onApplicationTerminatedObserver = userDefaults.observe(\.onApplicationTerminated, options: [.new]) { (defaults, change) in
+            self.logger.info("Observer detected a onQuitApplicationWithBroadcastActive request!")
+            finishBroadcastGracefully(self)
+        }
+        
         // Listen for createOffer requests from the UI APP
         logger.info("Configuring observer for createOffer")
-        self.createOfferCallObserver = userDefaults.observe(\.createScreenShareOffer, options: [.new]) { (defaults, change) in
+        self.createScreenShareOfferObserver = userDefaults.observe(\.createScreenShareOffer, options: [.new]) { (defaults, change) in
             self.logger.info("Observer detected a createScreenShareOffer request!")
             
             Task.init {
@@ -56,7 +64,7 @@ open class BBBSampleHandler : RPBroadcastSampleHandler {
         }
         
         logger.info("Configuring observer for setRemoteSDP")
-        self.setRemoteSDPCallObserver = userDefaults.observe(\.setScreenShareRemoteSDP, options: [.new]) { (defaults, change) in
+        self.setScreenShareRemoteSDPOBserver = userDefaults.observe(\.setScreenShareRemoteSDP, options: [.new]) { (defaults, change) in
             let payload:String = (change.newValue!);
             // self.logger.info("Observer detected a setScreenShareRemoteSDP request with payload \(payload)")
             self.logger.info("Observer detected a setScreenShareRemoteSDP request")

--- a/ios-broadcast-upload-extension/Classes/FinishBroadcastService.h
+++ b/ios-broadcast-upload-extension/Classes/FinishBroadcastService.h
@@ -1,0 +1,16 @@
+//
+//  SampleHandler.h
+//  BigBlueButton Broadcast
+//
+//  Created by Gustavo Emanuel Farias Rosa on 09/05/22.
+//
+
+#ifndef SampleHandler_h
+#define SampleHandler_h
+
+#import <ReplayKit/ReplayKit.h>
+#import <Foundation/Foundation.h>
+
+void finishBroadcastGracefully(RPBroadcastSampleHandler * _Nonnull broadcastSampleHandler);
+
+#endif /* SampleHandler_h */

--- a/ios-broadcast-upload-extension/Classes/FinishBroadcastService.m
+++ b/ios-broadcast-upload-extension/Classes/FinishBroadcastService.m
@@ -1,0 +1,17 @@
+//
+//  SampleHandler.m
+//  BigBlueButton Broadcast
+//
+//  Created by Gustavo Emanuel Farias Rosa on 09/05/22.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "FinishBroadcastService.h"
+
+void finishBroadcastGracefully(RPBroadcastSampleHandler * _Nonnull broadcastSampleHandler) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    [broadcastSampleHandler finishBroadcastWithError:nil];
+#pragma clang diagnostic pop
+}

--- a/ios-broadcast-upload-extension/bigbluebutton-mobile-sdk-broadcast-upload-extension.podspec
+++ b/ios-broadcast-upload-extension/bigbluebutton-mobile-sdk-broadcast-upload-extension.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/bigbluebutton/bigbluebutton-mobile-sdk.git", :tag => "#{s.version}" }
 
   s.source_files = "Classes/*.{h,m,mm,swift}"
-
+  s.public_header_files = ["Classes/*.h"]
   s.dependency "WebRTC-lib"
   s.dependency "bigbluebutton-mobile-sdk-common"
 end

--- a/ios-common/Classes/BBBSharedData.swift
+++ b/ios-common/Classes/BBBSharedData.swift
@@ -31,6 +31,7 @@ open class BBBSharedData {
         public static let onScreenShareLocalIceCandidate  = "onScreenShareLocalIceCandidate"  // Broadcaster -> UI APP
         
         public static let onScreenShareSignalingStateChange = "onScreenShareSignalingStateChange" // Broadcaster -> UI APP
+        public static let onApplicationTerminated = "onApplicationTerminated" // UI APP -> Broadcaster
         
     }
     

--- a/ios-common/Classes/UserDefaults.swift
+++ b/ios-common/Classes/UserDefaults.swift
@@ -10,6 +10,11 @@ extension UserDefaults {
         return string(forKey: BBBSharedData.SharedData.broadcastStarted) ?? ""
     }
     
+    // UI APP -> Broadcaster
+    @objc open dynamic var onApplicationTerminated: String {
+        return string(forKey: BBBSharedData.SharedData.onApplicationTerminated) ?? ""
+    }
+    
     // Broadcaster -> UI APP
     @objc open dynamic var broadcastPaused: String {
         return string(forKey: BBBSharedData.SharedData.broadcastPaused) ?? ""

--- a/ios/NativeOnly/BigBlueButtonSDK.swift
+++ b/ios/NativeOnly/BigBlueButtonSDK.swift
@@ -105,5 +105,11 @@ open class BigBlueButtonSDK: NSObject {
         observer1?.invalidate()
         observer2?.invalidate()
     }
+    
+    public static func onAppTerminated(){
+        BBBSharedData
+            .getUserDefaults(appGroupName: self.appGroupName)
+            .set(BBBSharedData.generatePayload(), forKey: BBBSharedData.SharedData.onApplicationTerminated)
+    }
 
 }


### PR DESCRIPTION
# What does this PR do?
- It implements a message from application to the broadcast extension notifying that the application has been closed.
- When this message is received on broadcast extension, it stops the broadcast.

- Fixed #5 
--------

![WhatsApp Image 2022-05-10 at 5 07 39 PM](https://user-images.githubusercontent.com/59415818/167713724-af90d4f9-7b14-438a-a0f1-cd70d16d6bb1.jpeg)

![WhatsApp Image 2022-05-10 at 5 11 23 PM](https://user-images.githubusercontent.com/59415818/167713710-455028a0-c16a-4da1-a363-44f401a66730.jpeg)

